### PR TITLE
Fix for #77 - word splitting in textareas

### DIFF
--- a/src/FormPage/FormPage.scss
+++ b/src/FormPage/FormPage.scss
@@ -106,7 +106,7 @@
     .form-control {
         padding: 6px 10px 3px;
         border-radius: 5px;
-        word-break: break-all;
+        word-break: break-word;
         min-height: 43px;
     }
     .btn-info {


### PR DESCRIPTION
![screenshot-localhost_9000-2019 10 18-13_52_58](https://user-images.githubusercontent.com/23515048/67127645-a1a41780-f1ae-11e9-89ef-779f80b5a7b2.png)

To be clear: this doesn't completely prevent word splitting (which wouldn't be intended behaviour anyway considering a long word would then overflow outside the text area).