### PR TITLE
Fix for #78 Change input color to black in focus

### DIFF
--- a/src/FormPage/FormPage.scss
+++ b/src/FormPage/FormPage.scss
@@ -28,7 +28,7 @@
         }
         &:focus {
             background-color: $background-color;
-            color: $text-gray;
+            color: $text-color;
             border: 2px solid $primary-color;
             box-shadow: 0 0 0 0;
         }


### PR DESCRIPTION
Fixed #78. Keeps placeholder text grey, but now typed-in text is always black, regardless of whether input is in focus.

![screenshot-localhost_9000-2019 10 18-14_12_16](https://user-images.githubusercontent.com/23515048/67128895-e7aeaa80-f1b1-11e9-8f72-269fea8a0470.png)
