### PR TITLE
Try allowing build:frontend to pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ node_js:
 script:
   - npm test
   - npm run build:backend
-  - travis_wait npm run build:frontend || true
+  - npm run build:frontend


### PR DESCRIPTION
@theopolisme it was disabled earlier because the travis CI server would run out of memory (the build:frontend would work on heroku because there was enough memory though).