### PR TITLE
fix: add checks for malformed jwt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11699,6 +11699,12 @@
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
+      "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+      "dev": true
+    },
     "pretty-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "morgan": "^1.9.1",
         "nodemon": "^1.19.3",
         "path": "^0.12.7",
+        "prettier": "^1.18.2",
         "query-string": "^5.1.1",
         "react": "^16.5.2",
         "react-dom": "^16.5.2",

--- a/src/__tests__/auth.unit.test.ts
+++ b/src/__tests__/auth.unit.test.ts
@@ -1,0 +1,22 @@
+import { parseJwt } from "../store/auth/actions";
+
+describe("auth helper functions", () => {
+  describe("parseJwt", () => {
+    test("parses regular jwt", () => {
+      expect(
+        parseJwt(
+          "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+        )
+      ).toMatchInlineSnapshot(`
+        Object {
+          "iat": 1516239022,
+          "name": "John Doe",
+          "sub": "1234567890",
+        }
+      `);
+    });
+    test("parses malformed jwt", () => {
+      expect(parseJwt("ABC")).toMatchInlineSnapshot(`null`);
+    });
+  });
+});

--- a/src/store/auth/actions.ts
+++ b/src/store/auth/actions.ts
@@ -44,8 +44,11 @@ export function logout() {
 }
 
 function parseJwt(token) {
-  var base64Url = token.split('.')[1];
-  var base64 = base64Url.replace('-', '+').replace('_', '/');
+  var base64UrlSplit = token.split('.');
+  if (!base64UrlSplit) return null;
+  const base64Url = base64UrlSplit[1];
+  if (!base64Url) return null;
+  const base64 = base64Url.replace('-', '+').replace('_', '/');
   return JSON.parse(window.atob(base64));
 };
 
@@ -70,7 +73,7 @@ const getCurrentUser = () => async (dispatch) => {
 
     // Verify JWT here.
     const parsed = parseJwt(jwt);
-    if (new Date().getTime() / 1000 >= parseInt(parsed.exp)) {
+    if (parsed && (new Date().getTime() / 1000 >= parseInt(parsed.exp))) {
       console.log("JWT expired");
       localStorage.removeItem("jwt");
       let refreshToken = localStorage.getItem("refresh_token");

--- a/src/store/auth/actions.ts
+++ b/src/store/auth/actions.ts
@@ -43,7 +43,7 @@ export function logout() {
   }
 }
 
-function parseJwt(token) {
+export function parseJwt(token) {
   var base64UrlSplit = token.split('.');
   if (!base64UrlSplit) return null;
   const base64Url = base64UrlSplit[1];
@@ -73,7 +73,11 @@ const getCurrentUser = () => async (dispatch) => {
 
     // Verify JWT here.
     const parsed = parseJwt(jwt);
-    if (parsed && (new Date().getTime() / 1000 >= parseInt(parsed.exp))) {
+    if (!parsed) {
+      console.log("JWT invalid");
+      localStorage.removeItem("jwt");
+    }
+    else if (new Date().getTime() / 1000 >= parseInt(parsed.exp)) {
       console.log("JWT expired");
       localStorage.removeItem("jwt");
       let refreshToken = localStorage.getItem("refresh_token");


### PR DESCRIPTION
Otherwise, the parseJwt function would intermittently error.