### PR TITLE
Disable reviewer, sponsor, judge roles

### DIFF
--- a/backend/__mocks__/constants.ts
+++ b/backend/__mocks__/constants.ts
@@ -208,5 +208,4 @@ export const HACKATHON_YEAR = "2020"; //settings.hackathon_year;
 export const HACKATHON_YEAR_STRING = String(HACKATHON_YEAR);
 export const AUTO_ADMIT_STANFORD = false;
 
-export const ALLOWED_GROUPS = ["admin"];
-// ["admin", "reviewer", "sponsor", "judge"];
+export const ALLOWED_GROUPS = ["admin", "reviewer", "sponsor", "judge"];

--- a/backend/__tests__/hacksList.unit.test.ts
+++ b/backend/__tests__/hacksList.unit.test.ts
@@ -4,6 +4,8 @@ import Hack from "../models/Hack";
 import { omit } from "lodash";
 import { hackReviewDisplayFields } from "../constants";
 
+jest.mock("../constants");
+
 let docs = [
     { _id: 1, floor: 1, title: 'test1', categories: [], devpostUrl: "abc", numSkips: 0, reviews: [{ reader: { id: "test", email: "test@test" } }] },
     { _id: 2, floor: 2, title: 'test2', categories: [], devpostUrl: "abc", numSkips: 0, reviews: [] },

--- a/backend/__tests__/judging.test.ts
+++ b/backend/__tests__/judging.test.ts
@@ -5,6 +5,8 @@ import Judge from "../models/Judge";
 import { isEqual, omit } from "lodash";
 import { STATUS, TYPE, hackReviewDisplayFields } from '../constants';
 
+jest.mock("../constants");
+
 const _doc = {
     "title": "sample title",
     "devpostUrl": "sample url",

--- a/backend/__tests__/reviewer.test.ts
+++ b/backend/__tests__/reviewer.test.ts
@@ -4,6 +4,8 @@ import Application from "../models/Application";
 import { isEqual, omit } from "lodash";
 import { STATUS, HACKATHON_YEAR_STRING, applicationReviewDisplayFieldsNoSection, TYPE } from '../constants';
 
+jest.mock("../constants");
+
 afterEach(() => {
     return Application.deleteMany({});
 })

--- a/backend/__tests__/userFormList.test.ts
+++ b/backend/__tests__/userFormList.test.ts
@@ -5,6 +5,8 @@ import { isEqual, omit } from "lodash";
 import { STATUS, sponsorApplicationDisplayFieldsNoSection, HACKATHON_YEAR_STRING } from '../constants';
 import queryString from "query-string";
 
+jest.mock("../constants");
+
 const _doc = {
     reviews: [],
     status: STATUS.INCOMPLETE,

--- a/backend/router/authenticatedRoute.ts
+++ b/backend/router/authenticatedRoute.ts
@@ -1,6 +1,7 @@
 import CognitoExpress from "cognito-express";
 import express from "express";
 import {get} from "lodash";
+import {ALLOWED_GROUPS} from "../constants";
 
 //Initializing CognitoExpress constructor
 const cognitoExpress = new CognitoExpress({
@@ -41,6 +42,8 @@ authenticatedRoute.param('userId', (req, res, next, userId) => {
 const validateGroup = (group, allowAnonymous = false) => (req, res, next) => {
   // Allow either a single group or multiple valid groups passed as an array
   if (!Array.isArray(group)) { group = [group]; }
+
+  group = group.filter(e => ALLOWED_GROUPS.indexOf(e) > -1);
   
   group.push("admin"); // admins have access to all routes.
 


### PR DESCRIPTION
This only disables the backend endpoints.

Also mocks the constants.ts file in tests so that the tests will still pass (even if certain endpoints are disabled).