### PR TITLE
Fix application collection name

### DIFF
--- a/backend/models/Application.ts
+++ b/backend/models/Application.ts
@@ -28,5 +28,5 @@ function setCurrentYear(this: IApplication) {
     }
 }
 
-const model: Model<IApplication> = mongoose.model("Application", applicationCurrentYearSchema, "Application");
+const model: Model<IApplication> = mongoose.model("Application", applicationCurrentYearSchema, "applications");
 export default model;


### PR DESCRIPTION
Previously, it was creating a new collection called "Application"
to store all the new applications. However, we want to use the same
collection as was used last year, which is called "applications".