### PR TITLE
Fix viewing preview of forms in admin

### DIFF
--- a/src/Admin/AdminTable.tsx
+++ b/src/Admin/AdminTable.tsx
@@ -50,7 +50,7 @@ const AdminTable = (props: IAdminTableProps) => {
     const columns = [
         {
             "Header": "Preview",
-            "accessor": "_id",
+            "accessor": "user.id",
             "id": "preview",
             "filterable": false,
             "Cell": (p) => <div><a onClick={(e) => {


### PR DESCRIPTION
Fixes #106. This is because the endpoint requires the user id, not the actual
form id, to view the form information.