### PR TITLE
sort leaderboard by all or 7d

### DIFF
--- a/src/Review/Review.scss
+++ b/src/Review/Review.scss
@@ -81,6 +81,10 @@
     padding-bottom: 5px;
 }
 
+.pointer {
+    cursor: pointer;
+}
+
 @media only screen and (min-width:768px) {
     .treehacks-review-form {
         position: fixed;

--- a/src/Review/Review.tsx
+++ b/src/Review/Review.tsx
@@ -14,7 +14,8 @@ interface IReviewComponentState {
 	leaderboard_data: any[],
 	application_data: { _id: string, user: { id: string }, forms: { application_info: any } },
 	stats_data: any,
-	reviewFormData: any
+	reviewFormData: any,
+	sortByRecent: boolean
 }
 
 const bools = {
@@ -82,7 +83,8 @@ class Review extends React.Component<IReviewProps, IReviewComponentState> {
 			leaderboard_data: null,
 			application_data: null,
 			stats_data: null,
-			reviewFormData: null
+			reviewFormData: null,
+			sortByRecent: false,
 		}
 	}
 
@@ -103,7 +105,7 @@ class Review extends React.Component<IReviewProps, IReviewComponentState> {
 		});
 	}
 	getSortedLeaderboardByRecent(leaderboard) {
-		return leaderboard.concat().sort((a, b) => (a.recentCount > b.recentCount) ? 1 : -1);
+		return leaderboard.concat().sort((a, b) => (a.recentCount > b.recentCount) ? -1 : 1);
 	}
 
 	render() {
@@ -174,10 +176,10 @@ class Review extends React.Component<IReviewProps, IReviewComponentState> {
 						<tbody>
 							<tr>
 								<th>Reviewer</th>
-								<th>All</th>
-								<th>7d</th>
+								<th className="pointer" onClick={() => this.setState({ sortByRecent: false })}>All</th>
+								<th className="pointer" onClick={() => this.setState({ sortByRecent: true })}>7d</th>
 							</tr>
-							{this.state.leaderboard_data && this.state.leaderboard_data.map(person => <tr key={person._id}>
+							{this.state.leaderboard_data && (this.state.sortByRecent ? this.getSortedLeaderboardByRecent(this.state.leaderboard_data) : this.state.leaderboard_data).map(person => <tr key={person._id}>
 								<td>{(person._id || "None").replace(/@stanford.edu/, "")}</td>
 								<td>{person.count}</td>
 								<td>{person.recentCount}</td>


### PR DESCRIPTION
Fix for #152 - click on "all" or "7d" headers to sort by those respective parameters.