### PR TITLE
Add IGNORED_REVIEWERS to constants mocks

### DIFF
--- a/backend/__mocks__/constants.ts
+++ b/backend/__mocks__/constants.ts
@@ -208,4 +208,6 @@ export const HACKATHON_YEAR = "2020"; //settings.hackathon_year;
 export const HACKATHON_YEAR_STRING = String(HACKATHON_YEAR);
 export const AUTO_ADMIT_STANFORD = false;
 
+export const IGNORED_REVIEWERS = [];
+
 export const ALLOWED_GROUPS = ["admin", "reviewer", "sponsor", "judge"];


### PR DESCRIPTION
Whenever we add a new constant we need to add it to the mocks file -- this
is what allows the snapshots to be consistent regardless of our constants
configuration @theopolisme