### PR TITLE
Add image to meet_info, create script for getting slack profile pictures

### DIFF
--- a/backend/__tests__/meetForm.test.ts
+++ b/backend/__tests__/meetForm.test.ts
@@ -14,7 +14,7 @@ describe('meet form', () => {
         await new Application({
             user: { id: 'applicanttreehacks' },
             forms: {
-                meet_info: {idea: "hello"},
+                meet_info: {idea: "hello", profilePicture: "mypicture"},
                 application_info: {first_name: "ash", last_name: "ram"}
             }
         }).save();
@@ -23,7 +23,7 @@ describe('meet form', () => {
             .set({ Authorization: 'applicant' })
             .expect(200)
             .then(e => {
-                expect(e.body).toEqual({ idea: "hello", first_name: "ash", last_initial: "r" });
+                expect(e.body).toEqual({ idea: "hello", profilePicture: "mypicture", first_name: "ash", last_initial: "r" });
             });
     });
     test('view meet info should work and show defaults when meet info is not defined', async () => {

--- a/backend/models/Application.d.ts
+++ b/backend/models/Application.d.ts
@@ -46,7 +46,10 @@ export interface IMeetInfo {
   idea?: String,
   pronouns?: String,
   showProfile?: Boolean,
-  
+
+  // populated from script
+  profilePicture?: String,
+
   // dynamically populated from API:
   first_name?: String,
   last_initial?: String

--- a/backend/models/meetInfoSchema.ts
+++ b/backend/models/meetInfoSchema.ts
@@ -7,6 +7,7 @@ const meetInfoSchema: Schema = new mongoose.Schema({
     showProfile: Boolean,
     pronouns: String,
     // will be prepopulated -- need to add them to the schema so that they can be set
+    profilePicture: String,
     first_name: String,
     last_initial: String
 }, { _id: false });

--- a/backend/scripts/fetch_slack_profile_pictures.py
+++ b/backend/scripts/fetch_slack_profile_pictures.py
@@ -13,7 +13,10 @@ slack_client = slack.WebClient(token=os.environ['SLACK_OAUTH_ACCESS_TOKEN'])
 for app in applications:
     if 'meet_info' in app['forms']:
         user_email = app['user']['email']
-        user_resp = slack_client.users_lookupByEmail(email=user_email)
+        try:
+            user_resp = slack_client.users_lookupByEmail(email=user_email)
+        except slack.errors.SlackApiError:
+            continue
         image_link = user_resp['user']['profile']['image_512']
         db.applications.update_one({
             '_id': app['_id']

--- a/backend/scripts/fetch_slack_profile_pictures.py
+++ b/backend/scripts/fetch_slack_profile_pictures.py
@@ -1,3 +1,8 @@
+'''This script updates the profilePicture field in the Mongo database with users' Slack profile pictures. The script
+is intended to be run periodically with a cron job or similar. The script accesses MONGODB_URI and
+SLACK_OAUTH_ACCESS_TOKEN environment variables.
+'''
+
 import os
 import slack
 from dotenv import load_dotenv

--- a/backend/scripts/fetch_slack_profile_pictures.py
+++ b/backend/scripts/fetch_slack_profile_pictures.py
@@ -5,7 +5,7 @@ from pymongo import MongoClient
 
 dotenv_path = '.env'
 load_dotenv(dotenv_path)
-client = MongoClient(os.environ['MONGODB_URI']);
+client = MongoClient(os.environ['MONGODB_URI'], retryWrites=False);
 db = client['heroku_2r7kmznv']
 applications = db.applications.find()
 slack_client = slack.WebClient(token=os.environ['SLACK_OAUTH_ACCESS_TOKEN'])
@@ -15,5 +15,12 @@ for app in applications:
         user_email = app['user']['email']
         user_resp = slack_client.users_lookupByEmail(email=user_email)
         image_link = user_resp['user']['profile']['image_192']
+        db.applications.update_one({
+            '_id': app['_id']
+        },{
+            '$set': {
+                'forms.meet_info.profilePicture': image_link
+            }
+        }, upsert=False)
 
 client.close()

--- a/backend/scripts/fetch_slack_profile_pictures.py
+++ b/backend/scripts/fetch_slack_profile_pictures.py
@@ -1,0 +1,19 @@
+import os
+import slack
+from dotenv import load_dotenv
+from pymongo import MongoClient
+
+dotenv_path = '.env'
+load_dotenv(dotenv_path)
+client = MongoClient(os.environ['MONGODB_URI']);
+db = client['heroku_2r7kmznv']
+applications = db.applications.find()
+slack_client = slack.WebClient(token=os.environ['SLACK_OAUTH_ACCESS_TOKEN'])
+
+for app in applications:
+    if 'meet_info' in app['forms']:
+        user_email = app['user']['email']
+        user_resp = slack_client.users_lookupByEmail(email=user_email)
+        image_link = user_resp['user']['profile']['image_192']
+
+client.close()

--- a/backend/scripts/fetch_slack_profile_pictures.py
+++ b/backend/scripts/fetch_slack_profile_pictures.py
@@ -1,29 +1,33 @@
 import os
 import slack
 from dotenv import load_dotenv
-from pymongo import MongoClient
+from pymongo import MongoClient, uri_parser
 
 dotenv_path = '.env'
 load_dotenv(dotenv_path)
-client = MongoClient(os.environ['MONGODB_URI'], retryWrites=False);
-db = client['heroku_2r7kmznv']
-applications = db.applications.find()
+
+mongo_uri = os.environ['MONGODB_URI']
+client = MongoClient(mongo_uri, retryWrites=False);
+uri_dict = uri_parser.parse_uri(mongo_uri)
+db = client[uri_dict['database']]
+applications = db.applications.find({'year': '2020', 'forms.meet_info': {'$exists': True}})
 slack_client = slack.WebClient(token=os.environ['SLACK_OAUTH_ACCESS_TOKEN'])
 
 for app in applications:
-    if 'meet_info' in app['forms']:
-        user_email = app['user']['email']
-        try:
-            user_resp = slack_client.users_lookupByEmail(email=user_email)
-        except slack.errors.SlackApiError:
-            continue
-        image_link = user_resp['user']['profile']['image_512']
-        db.applications.update_one({
-            '_id': app['_id']
-        },{
-            '$set': {
-                'forms.meet_info.profilePicture': image_link
-            }
-        }, upsert=False)
+    user_email = app['user']['email']
+    try:
+        user_resp = slack_client.users_lookupByEmail(email=user_email)
+    except slack.errors.SlackApiError:
+        continue
+    image_link = user_resp['user']['profile']['image_512']
+    if image_link == app['forms']['meet_info']['profilePicture']:
+        continue
+    db.applications.update_one({
+        '_id': app['_id']
+    },{
+        '$set': {
+            'forms.meet_info.profilePicture': image_link
+        }
+    }, upsert=False)
 
 client.close()

--- a/backend/scripts/fetch_slack_profile_pictures.py
+++ b/backend/scripts/fetch_slack_profile_pictures.py
@@ -14,7 +14,7 @@ for app in applications:
     if 'meet_info' in app['forms']:
         user_email = app['user']['email']
         user_resp = slack_client.users_lookupByEmail(email=user_email)
-        image_link = user_resp['user']['profile']['image_192']
+        image_link = user_resp['user']['profile']['image_512']
         db.applications.update_one({
             '_id': app['_id']
         },{


### PR DESCRIPTION
I think this should work, not fully tested since the code in this PR will add the `profilePicture` field to `meet_info`. However, the script does add the correct field to the mongo database. 

Outstanding task:
- Right now, the database is hard-coded (`heroku_....`). This should probably be an environment variable. However, I wonder if there is a way to not create a new one and leverage the `MONGODB_URI` variable to get the same effect.