### PR TITLE
Hide unused admin tabs

### DIFF
--- a/src/Admin/Admin.tsx
+++ b/src/Admin/Admin.tsx
@@ -16,12 +16,12 @@ const Admin = ({ match }) => {
   return (
     <div className="bg-white col-8 offset-2 p-4">
       <NavTab to={`${match.path}/table`}>Application Table</NavTab>
-      <NavTab to={`${match.path}/hack_table`}>Hack Table</NavTab>
+      {/* <NavTab to={`${match.path}/hack_table`}>Hack Table</NavTab>
       <NavTab to={`${match.path}/judge_table`}>Judge Table</NavTab>
-      <NavTab to={`${match.path}/judge_leaderboard`}>Judge Leaderboard</NavTab>
+      <NavTab to={`${match.path}/judge_leaderboard`}>Judge Leaderboard</NavTab> */}
       <NavTab to={`${match.path}/bulkchange`}>Bulk Change Status</NavTab>
       <NavTab to={`${match.path}/bulkcreate`}>Bulk Create Users</NavTab>
-      <NavTab to={`${match.path}/bulk_import_hacks`}>Bulk Import Hacks</NavTab>
+      {/* <NavTab to={`${match.path}/bulk_import_hacks`}>Bulk Import Hacks</NavTab> */}
       <NavTab to={`${match.path}/stats`}>Application Stats</NavTab>
 
       <Switch>


### PR DESCRIPTION
Hide unused admin tabs for now -- this is part of #177.

We should actually remove all code relating to this functionality, but I'm just doing this now so that the screenshots look good when we create docs for the portal.