### PR TITLE
fix: updating text at end of application process

### DIFF
--- a/src/Dashboard/Dashboard.tsx
+++ b/src/Dashboard/Dashboard.tsx
@@ -112,8 +112,7 @@ export const Dashboard = (props: IDashboardProps) => {
               now!
               <br />
               <br />
-              We will email you when decisions are released and will handle any
-              travel questions at that time. Thanks for applying :)
+              We will email you when decisions are released. Thanks for applying :)
             </span>
           ) : currentDate > deadlineDate.getTime() ? (
             <span>Sorry, the application window has closed.</span>

--- a/src/__tests__/__snapshots__/dashboard.unit.test.tsx.snap
+++ b/src/__tests__/__snapshots__/dashboard.unit.test.tsx.snap
@@ -382,7 +382,7 @@ exports[`dashboard submitted 1`] = `
         Your application has been received – you are all good for now!
         <br />
         <br />
-        We will email you when decisions are released and will handle any travel questions at that time. Thanks for applying :)
+        We will email you when decisions are released. Thanks for applying :)
       </span>
     </div>
   </div>


### PR DESCRIPTION
At the end of the application flow (after submitting), users are prompted with text saying "we will email you when decisions are released and will handle any travel questions at that time". 

This PR removes the "and will handle any travel questions at that time" part of the sentence, to reflect the virtual hackathon this year. Please feel free to change up the text and/or test this once more, I just wanted to make a quick fix/suggestion!

